### PR TITLE
Replace GH action versions with specific commit hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: [3.9, '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@7a69c2bc7dc38832443a11bc7c2550ba96c6f45c
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: [3.9, '3.10']
 
     steps:
-    - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@7a69c2bc7dc38832443a11bc7c2550ba96c6f45c
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       with:
         persist-credentials: false
     - name: Install hyswap, dependencies, and Sphinx then build docs
@@ -39,7 +39,7 @@ jobs:
         echo ${{ github.ref == 'refs/heads/main' }}
         echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@22a6ee251d6f13c6ab1ecb200d974f1a6feb1b8d
+      uses: JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       with:
         persist-credentials: false
     - name: Install hyswap, dependencies, and Sphinx then build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       with:
         persist-credentials: false
     - name: Install hyswap, dependencies, and Sphinx then build docs
@@ -39,7 +39,7 @@ jobs:
         echo ${{ github.ref == 'refs/heads/main' }}
         echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4.4.2
+      uses: JamesIves/github-pages-deploy-action@22a6ee251d6f13c6ab1ecb200d974f1a6feb1b8d
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
     - name: Set up Python
       uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
       with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,9 +19,9 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -33,4 +33,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+      uses: pypa/gh-action-pypi-publish@37e305e7413032d8422456179fee28fac7d25187

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,9 +19,9 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
     - name: Set up Python
-      uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -33,4 +33,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@37e305e7413032d8422456179fee28fac7d25187
+      uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597


### PR DESCRIPTION
There is a potential security risk where the maintainer of a GitHub Action could retroactively change the code associated with specific, tagged versions of the action (e.g., v1, v2). Laura DeCicco proposed an alternative to replace version numbers in GitHub Action yml files with the specific commit hashes associated with those release versions, which are immutable. 

This PR makes those changes for the seven instances where an external action is invoked. I couldn't identify the exact version for some of the actions (e.g., there are multiple v2.#.# versions for checkout), which may explain why the build actions are currently failing. Or perhaps I don't have the permissions to run certain commands in the repo. Feel free to propose different commit hashes if you know more than I do about the action versions.

- actions/checkout
  - @v2: https://github.com/actions/checkout/commit/722adc63f1aa60a57ec37892e133b1d319cae598
  - @v3: https://github.com/actions/checkout/commit/2541b1294d2704b0964813337f33b291d3f8596b
- actions/setup-python
  - @v2: https://github.com/actions/setup-python/commit/7a69c2bc7dc38832443a11bc7c2550ba96c6f45c
  - @v3: https://github.com/actions/setup-python/commit/0ebf233433c08fb9061af664d501c3f3ff0e9e20
- JamesIves/github-pages-deploy-action: 
  - @v4.4.2: https://github.com/JamesIves/github-pages-deploy-action/commit/22a6ee251d6f13c6ab1ecb200d974f1a6feb1b8d
- pypa/gh-action-pypi-publisn:
  - @v1: https://github.com/pypa/gh-action-pypi-publish/commit/37e305e7413032d8422456179fee28fac7d25187